### PR TITLE
Pil seviyesi kullanıcı tarafından belirlenebilecek seviyeye düştüğünde otomatik olarak güç profilini değiştirme özelliği ve iki hatanın düzeltilmesi

### DIFF
--- a/files/ppm.conf
+++ b/files/ppm.conf
@@ -5,3 +5,6 @@ ppm-mode-battery = 1
 udev-enabled = true
 udev-brightness = true
 force-enable-app = false
+low-battery-enabled = false
+low-battery-profile = 0
+low-battery-threshold = 20

--- a/po/power-manager-pt.po
+++ b/po/power-manager-pt.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pardus power manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-08 23:14+0300\n"
-"PO-Revision-Date: 2022-07-22 10:59+0100\n"
+"POT-Creation-Date: 2023-02-09 18:45+0300\n"
+"PO-Revision-Date: 2023-02-09 18:47+0300\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Português <hugokarvalho@hotmail.com>\n"
 "Language: pt\n"
@@ -18,6 +18,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
+
+#: src/main.py:76
+msgid "Your computer does not need power management."
+msgstr "O seu computador não necessita de gestão de energia."
+
+#: src/main.py:77
+msgid "Do you want to enable it anyway?"
+msgstr "Quer ativá-la mesmo assim?"
+
+#: src/main.py:85
+msgid "No"
+msgstr "Não"
+
+#: src/main.py:86
+msgid "Yes"
+msgstr "Sim"
+
+#: src/MainWindow.py:39 src/MainWindow.py:255 ui/MainWindow.glade:908
+msgid "Pardus Power Manager"
+msgstr "Gestor de Energia Pardus"
+
+#: src/StatusIcon.py:41
+msgid "View"
+msgstr "Ver"
+
+#: src/StatusIcon.py:48
+msgid "Power"
+msgstr "Energia"
+
+#: src/StatusIcon.py:64
+msgid "Settings"
+msgstr "Definições"
 
 #: ui/MainWindow.glade:7
 msgid "About"
@@ -142,27 +174,27 @@ msgstr ""
 
 #: ui/MainWindow.glade:827
 msgid "5"
-msgstr ""
+msgstr "5"
 
 #: ui/MainWindow.glade:828
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #: ui/MainWindow.glade:829
 msgid "15"
-msgstr ""
+msgstr "15"
 
 #: ui/MainWindow.glade:830
 msgid "20"
-msgstr ""
+msgstr "20"
 
 #: ui/MainWindow.glade:831
 msgid "25"
-msgstr ""
+msgstr "25"
 
 #: ui/MainWindow.glade:832
 msgid "30"
-msgstr ""
+msgstr "30"
 
 #: ui/MainWindow.glade:863
 msgid "settings"
@@ -171,28 +203,3 @@ msgstr "definições"
 #: ui/MainWindow.glade:891
 msgid "TÜBİTAK ULAKBİM | 2022"
 msgstr "TÜBİTAK ULAKBİM | 2022"
-
-#: ui/MainWindow.glade:908
-msgid "Pardus Power Manager"
-msgstr "Gestor de Energia Pardus"
-
-#~ msgid "View"
-#~ msgstr "Ver"
-
-#~ msgid "Power"
-#~ msgstr "Energia"
-
-#~ msgid "Settings"
-#~ msgstr "Definições"
-
-#~ msgid "Your computer does not need power management."
-#~ msgstr "O seu computador não necessita de gestão de energia."
-
-#~ msgid "Do you want to enable it anyway?"
-#~ msgstr "Quer ativá-la mesmo assim?"
-
-#~ msgid "No"
-#~ msgstr "Não"
-
-#~ msgid "Yes"
-#~ msgstr "Sim"

--- a/po/power-manager-pt.po
+++ b/po/power-manager-pt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pardus power manager\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-19 11:34+0300\n"
+"POT-Creation-Date: 2023-02-08 23:14+0300\n"
 "PO-Revision-Date: 2022-07-22 10:59+0100\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Português <hugokarvalho@hotmail.com>\n"
@@ -18,38 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
-
-#: src/MainWindow.py:39 src/MainWindow.py:241 ui/MainWindow.glade:781
-msgid "Pardus Power Manager"
-msgstr "Gestor de Energia Pardus"
-
-#: src/StatusIcon.py:41
-msgid "View"
-msgstr "Ver"
-
-#: src/StatusIcon.py:48
-msgid "Power"
-msgstr "Energia"
-
-#: src/StatusIcon.py:64
-msgid "Settings"
-msgstr "Definições"
-
-#: src/main.py:74
-msgid "Your computer does not need power management."
-msgstr "O seu computador não necessita de gestão de energia."
-
-#: src/main.py:75
-msgid "Do you want to enable it anyway?"
-msgstr "Quer ativá-la mesmo assim?"
-
-#: src/main.py:83
-msgid "No"
-msgstr "Não"
-
-#: src/main.py:84
-msgid "Yes"
-msgstr "Sim"
 
 #: ui/MainWindow.glade:7
 msgid "About"
@@ -76,10 +44,12 @@ msgid "Power Save"
 msgstr "Poupança de Energia"
 
 #: ui/MainWindow.glade:249 ui/MainWindow.glade:652 ui/MainWindow.glade:696
+#: ui/MainWindow.glade:785
 msgid "Balanced"
 msgstr "Equilibrado"
 
 #: ui/MainWindow.glade:305 ui/MainWindow.glade:653 ui/MainWindow.glade:697
+#: ui/MainWindow.glade:786
 msgid "Performance"
 msgstr "Desempenho"
 
@@ -140,15 +110,15 @@ msgstr "Alterar o perfil de energia quando ligar/desligar da corrente"
 msgid "Power profile on AC"
 msgstr "Perfil de energia ligado à corrente"
 
-#: ui/MainWindow.glade:650 ui/MainWindow.glade:694
+#: ui/MainWindow.glade:650 ui/MainWindow.glade:694 ui/MainWindow.glade:783
 msgid "Extreme Powersave"
 msgstr "Poupança de Energia Extrema"
 
-#: ui/MainWindow.glade:651 ui/MainWindow.glade:695
+#: ui/MainWindow.glade:651 ui/MainWindow.glade:695 ui/MainWindow.glade:784
 msgid "Powersave"
 msgstr "Poupança de Energia"
 
-#: ui/MainWindow.glade:654 ui/MainWindow.glade:698
+#: ui/MainWindow.glade:654 ui/MainWindow.glade:698 ui/MainWindow.glade:787
 msgid "Extreme Performance"
 msgstr "Desempenho Extremo"
 
@@ -156,10 +126,73 @@ msgstr "Desempenho Extremo"
 msgid "Power profile on battery"
 msgstr "Perfil de energia a bateria"
 
-#: ui/MainWindow.glade:736
+#: ui/MainWindow.glade:731
+#, fuzzy
+msgid "Change profile on low battery"
+msgstr "Perfil de energia a bateria"
+
+#: ui/MainWindow.glade:769
+#, fuzzy
+msgid "Power profile on low battery"
+msgstr "Perfil de energia a bateria"
+
+#: ui/MainWindow.glade:813
+msgid "Low battery threshold"
+msgstr ""
+
+#: ui/MainWindow.glade:827
+msgid "5"
+msgstr ""
+
+#: ui/MainWindow.glade:828
+msgid "10"
+msgstr ""
+
+#: ui/MainWindow.glade:829
+msgid "15"
+msgstr ""
+
+#: ui/MainWindow.glade:830
+msgid "20"
+msgstr ""
+
+#: ui/MainWindow.glade:831
+msgid "25"
+msgstr ""
+
+#: ui/MainWindow.glade:832
+msgid "30"
+msgstr ""
+
+#: ui/MainWindow.glade:863
 msgid "settings"
 msgstr "definições"
 
-#: ui/MainWindow.glade:764
+#: ui/MainWindow.glade:891
 msgid "TÜBİTAK ULAKBİM | 2022"
 msgstr "TÜBİTAK ULAKBİM | 2022"
+
+#: ui/MainWindow.glade:908
+msgid "Pardus Power Manager"
+msgstr "Gestor de Energia Pardus"
+
+#~ msgid "View"
+#~ msgstr "Ver"
+
+#~ msgid "Power"
+#~ msgstr "Energia"
+
+#~ msgid "Settings"
+#~ msgstr "Definições"
+
+#~ msgid "Your computer does not need power management."
+#~ msgstr "O seu computador não necessita de gestão de energia."
+
+#~ msgid "Do you want to enable it anyway?"
+#~ msgstr "Quer ativá-la mesmo assim?"
+
+#~ msgid "No"
+#~ msgstr "Não"
+
+#~ msgid "Yes"
+#~ msgstr "Sim"

--- a/po/power-manager-tr.po
+++ b/po/power-manager-tr.po
@@ -8,48 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: unnamed project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-19 11:34+0300\n"
-"PO-Revision-Date: 2021-12-21 12:16+0300\n"
+"POT-Creation-Date: 2023-02-08 23:14+0300\n"
+"PO-Revision-Date: 2023-02-09 14:49+0300\n"
 "Last-Translator: Yusuf Düzgün <yusuf.duzgun@pardus.org.tr>\n"
 "Language-Team: Turkish <gelistirici@pardus.org.tr>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Gtranslator 3.38.0\n"
-"Plural-Forms: nplurals=1; plural=0\n"
-
-#: src/MainWindow.py:39 src/MainWindow.py:241 ui/MainWindow.glade:781
-msgid "Pardus Power Manager"
-msgstr "Pardus Güç Yöneticisi"
-
-#: src/StatusIcon.py:41
-msgid "View"
-msgstr "Göster"
-
-#: src/StatusIcon.py:48
-msgid "Power"
-msgstr "Güç"
-
-#: src/StatusIcon.py:64
-msgid "Settings"
-msgstr "Ayarlar"
-
-#: src/main.py:74
-msgid "Your computer does not need power management."
-msgstr "Bilgisayarınızın güç yönetimine ihtiyacı yoktur."
-
-#: src/main.py:75
-msgid "Do you want to enable it anyway?"
-msgstr "Yine de etkinleştirmek istiyor musunuz?"
-
-#: src/main.py:83
-msgid "No"
-msgstr "Hayır"
-
-#: src/main.py:84
-msgid "Yes"
-msgstr "Evet"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #: ui/MainWindow.glade:7
 msgid "About"
@@ -76,10 +44,12 @@ msgid "Power Save"
 msgstr "Güç tasarrufu"
 
 #: ui/MainWindow.glade:249 ui/MainWindow.glade:652 ui/MainWindow.glade:696
+#: ui/MainWindow.glade:785
 msgid "Balanced"
 msgstr "Dengeli"
 
 #: ui/MainWindow.glade:305 ui/MainWindow.glade:653 ui/MainWindow.glade:697
+#: ui/MainWindow.glade:786
 msgid "Performance"
 msgstr "Performans"
 
@@ -139,15 +109,15 @@ msgstr "Fişe takıldığında veya çıkarıldığında güç profilini değiş
 msgid "Power profile on AC"
 msgstr "Fişe takılıyken güç profili"
 
-#: ui/MainWindow.glade:650 ui/MainWindow.glade:694
+#: ui/MainWindow.glade:650 ui/MainWindow.glade:694 ui/MainWindow.glade:783
 msgid "Extreme Powersave"
 msgstr "Yüksek Güç Tasarrufu"
 
-#: ui/MainWindow.glade:651 ui/MainWindow.glade:695
+#: ui/MainWindow.glade:651 ui/MainWindow.glade:695 ui/MainWindow.glade:784
 msgid "Powersave"
 msgstr "Güç Tasarrufu"
 
-#: ui/MainWindow.glade:654 ui/MainWindow.glade:698
+#: ui/MainWindow.glade:654 ui/MainWindow.glade:698 ui/MainWindow.glade:787
 msgid "Extreme Performance"
 msgstr "Yüksek Performans"
 
@@ -155,10 +125,71 @@ msgstr "Yüksek Performans"
 msgid "Power profile on battery"
 msgstr "Pildeyken güç profili"
 
-#: ui/MainWindow.glade:736
+#: ui/MainWindow.glade:731
+msgid "Change profile on low battery"
+msgstr "Pil seviyesi düşünce güç profilini değiştir"
+
+#: ui/MainWindow.glade:769
+msgid "Power profile on low battery"
+msgstr "Pil seviyesi düşükken güç profili"
+
+#: ui/MainWindow.glade:813
+msgid "Low battery threshold"
+msgstr "Pil seviyesi düşük sınırı"
+
+#: ui/MainWindow.glade:827
+msgid "5"
+msgstr "5"
+
+#: ui/MainWindow.glade:828
+msgid "10"
+msgstr "10"
+
+#: ui/MainWindow.glade:829
+msgid "15"
+msgstr "15"
+
+#: ui/MainWindow.glade:830
+msgid "20"
+msgstr "20"
+
+#: ui/MainWindow.glade:831
+msgid "25"
+msgstr "25"
+
+#: ui/MainWindow.glade:832
+msgid "30"
+msgstr "30"
+
+#: ui/MainWindow.glade:863
 msgid "settings"
 msgstr "ayarlar"
 
-#: ui/MainWindow.glade:764
+#: ui/MainWindow.glade:891
 msgid "TÜBİTAK ULAKBİM | 2022"
 msgstr "TÜBİTAK ULAKBİM | 2022"
+
+#: ui/MainWindow.glade:908
+msgid "Pardus Power Manager"
+msgstr "Pardus Güç Yöneticisi"
+
+#~ msgid "View"
+#~ msgstr "Göster"
+
+#~ msgid "Power"
+#~ msgstr "Güç"
+
+#~ msgid "Settings"
+#~ msgstr "Ayarlar"
+
+#~ msgid "Your computer does not need power management."
+#~ msgstr "Bilgisayarınızın güç yönetimine ihtiyacı yoktur."
+
+#~ msgid "Do you want to enable it anyway?"
+#~ msgstr "Yine de etkinleştirmek istiyor musunuz?"
+
+#~ msgid "No"
+#~ msgstr "Hayır"
+
+#~ msgid "Yes"
+#~ msgstr "Evet"

--- a/po/power-manager-tr.po
+++ b/po/power-manager-tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: unnamed project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-08 23:14+0300\n"
+"POT-Creation-Date: 2023-02-09 18:45+0300\n"
 "PO-Revision-Date: 2023-02-09 14:49+0300\n"
 "Last-Translator: Yusuf Düzgün <yusuf.duzgun@pardus.org.tr>\n"
 "Language-Team: Turkish <gelistirici@pardus.org.tr>\n"
@@ -18,6 +18,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.1.1\n"
+
+#: src/main.py:76
+msgid "Your computer does not need power management."
+msgstr "Bilgisayarınızın güç yönetimine ihtiyacı yoktur."
+
+#: src/main.py:77
+msgid "Do you want to enable it anyway?"
+msgstr "Yine de etkinleştirmek istiyor musunuz?"
+
+#: src/main.py:85
+msgid "No"
+msgstr "Hayır"
+
+#: src/main.py:86
+msgid "Yes"
+msgstr "Evet"
+
+#: src/MainWindow.py:39 src/MainWindow.py:255 ui/MainWindow.glade:908
+msgid "Pardus Power Manager"
+msgstr "Pardus Güç Yöneticisi"
+
+#: src/StatusIcon.py:41
+msgid "View"
+msgstr "Göster"
+
+#: src/StatusIcon.py:48
+msgid "Power"
+msgstr "Güç"
+
+#: src/StatusIcon.py:64
+msgid "Settings"
+msgstr "Ayarlar"
 
 #: ui/MainWindow.glade:7
 msgid "About"
@@ -168,28 +200,3 @@ msgstr "ayarlar"
 #: ui/MainWindow.glade:891
 msgid "TÜBİTAK ULAKBİM | 2022"
 msgstr "TÜBİTAK ULAKBİM | 2022"
-
-#: ui/MainWindow.glade:908
-msgid "Pardus Power Manager"
-msgstr "Pardus Güç Yöneticisi"
-
-#~ msgid "View"
-#~ msgstr "Göster"
-
-#~ msgid "Power"
-#~ msgstr "Güç"
-
-#~ msgid "Settings"
-#~ msgstr "Ayarlar"
-
-#~ msgid "Your computer does not need power management."
-#~ msgstr "Bilgisayarınızın güç yönetimine ihtiyacı yoktur."
-
-#~ msgid "Do you want to enable it anyway?"
-#~ msgstr "Yine de etkinleştirmek istiyor musunuz?"
-
-#~ msgid "No"
-#~ msgstr "Hayır"
-
-#~ msgid "Yes"
-#~ msgstr "Evet"

--- a/ppm.pot
+++ b/ppm.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-19 11:34+0300\n"
+"POT-Creation-Date: 2023-02-08 23:14+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,38 +16,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#: src/MainWindow.py:39 src/MainWindow.py:241 ui/MainWindow.glade:781
-msgid "Pardus Power Manager"
-msgstr ""
-
-#: src/StatusIcon.py:41
-msgid "View"
-msgstr ""
-
-#: src/StatusIcon.py:48
-msgid "Power"
-msgstr ""
-
-#: src/StatusIcon.py:64
-msgid "Settings"
-msgstr ""
-
-#: src/main.py:74
-msgid "Your computer does not need power management."
-msgstr ""
-
-#: src/main.py:75
-msgid "Do you want to enable it anyway?"
-msgstr ""
-
-#: src/main.py:83
-msgid "No"
-msgstr ""
-
-#: src/main.py:84
-msgid "Yes"
-msgstr ""
 
 #: ui/MainWindow.glade:7
 msgid "About"
@@ -72,10 +40,12 @@ msgid "Power Save"
 msgstr ""
 
 #: ui/MainWindow.glade:249 ui/MainWindow.glade:652 ui/MainWindow.glade:696
+#: ui/MainWindow.glade:785
 msgid "Balanced"
 msgstr ""
 
 #: ui/MainWindow.glade:305 ui/MainWindow.glade:653 ui/MainWindow.glade:697
+#: ui/MainWindow.glade:786
 msgid "Performance"
 msgstr ""
 
@@ -127,15 +97,15 @@ msgstr ""
 msgid "Power profile on AC"
 msgstr ""
 
-#: ui/MainWindow.glade:650 ui/MainWindow.glade:694
+#: ui/MainWindow.glade:650 ui/MainWindow.glade:694 ui/MainWindow.glade:783
 msgid "Extreme Powersave"
 msgstr ""
 
-#: ui/MainWindow.glade:651 ui/MainWindow.glade:695
+#: ui/MainWindow.glade:651 ui/MainWindow.glade:695 ui/MainWindow.glade:784
 msgid "Powersave"
 msgstr ""
 
-#: ui/MainWindow.glade:654 ui/MainWindow.glade:698
+#: ui/MainWindow.glade:654 ui/MainWindow.glade:698 ui/MainWindow.glade:787
 msgid "Extreme Performance"
 msgstr ""
 
@@ -143,10 +113,50 @@ msgstr ""
 msgid "Power profile on battery"
 msgstr ""
 
-#: ui/MainWindow.glade:736
+#: ui/MainWindow.glade:731
+msgid "Change profile on low battery"
+msgstr ""
+
+#: ui/MainWindow.glade:769
+msgid "Power profile on low battery"
+msgstr ""
+
+#: ui/MainWindow.glade:813
+msgid "Low battery threshold"
+msgstr ""
+
+#: ui/MainWindow.glade:827
+msgid "5"
+msgstr ""
+
+#: ui/MainWindow.glade:828
+msgid "10"
+msgstr ""
+
+#: ui/MainWindow.glade:829
+msgid "15"
+msgstr ""
+
+#: ui/MainWindow.glade:830
+msgid "20"
+msgstr ""
+
+#: ui/MainWindow.glade:831
+msgid "25"
+msgstr ""
+
+#: ui/MainWindow.glade:832
+msgid "30"
+msgstr ""
+
+#: ui/MainWindow.glade:863
 msgid "settings"
 msgstr ""
 
-#: ui/MainWindow.glade:764
+#: ui/MainWindow.glade:891
 msgid "TÜBİTAK ULAKBİM | 2022"
+msgstr ""
+
+#: ui/MainWindow.glade:908
+msgid "Pardus Power Manager"
 msgstr ""

--- a/ppm.pot
+++ b/ppm.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-08 23:14+0300\n"
+"POT-Creation-Date: 2023-02-09 18:45+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,38 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: src/main.py:76
+msgid "Your computer does not need power management."
+msgstr ""
+
+#: src/main.py:77
+msgid "Do you want to enable it anyway?"
+msgstr ""
+
+#: src/main.py:85
+msgid "No"
+msgstr ""
+
+#: src/main.py:86
+msgid "Yes"
+msgstr ""
+
+#: src/MainWindow.py:39 src/MainWindow.py:255 ui/MainWindow.glade:908
+msgid "Pardus Power Manager"
+msgstr ""
+
+#: src/StatusIcon.py:41
+msgid "View"
+msgstr ""
+
+#: src/StatusIcon.py:48
+msgid "Power"
+msgstr ""
+
+#: src/StatusIcon.py:64
+msgid "Settings"
+msgstr ""
 
 #: ui/MainWindow.glade:7
 msgid "About"
@@ -155,8 +187,4 @@ msgstr ""
 
 #: ui/MainWindow.glade:891
 msgid "TÜBİTAK ULAKBİM | 2022"
-msgstr ""
-
-#: ui/MainWindow.glade:908
-msgid "Pardus Power Manager"
 msgstr ""

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -116,17 +116,22 @@ class MainWindow:
 
         charge_limit = tools.profile.get_charge_limit()
         self.builder.get_object("ui_limit_battery").set_state(charge_limit)
-        power_names = ["xpowersave", "powersave", "balanced", "performance", "xperformance"]
-        mode_ac = power_names[int(config.get("ppm-mode-ac","3"))]
-        mode_bat = power_names[int(config.get("ppm-mode-battery","1"))]
+        mode_ac = config.get("ppm-mode-ac","3")
+        mode_bat = config.get("ppm-mode-battery","1")
+        low_battery_mode = config.get("low-battery-profile","0")
+        low_battery_threshold = config.get("low-battery-threshold", "20")
+        low_battery_state = config.get("low-battery-enabled", "true").lower() == "true"
         self.builder.get_object("ui_mode_battery").set_active_id(mode_bat)
         self.builder.get_object("ui_mode_ac").set_active_id(mode_ac)
-
-
+        self.builder.get_object("ui_low_battery_mode").set_active_id(low_battery_mode)
+        self.builder.get_object("ui_low_battery").set_state(low_battery_state)
+        self.builder.get_object("ui_low_battery_threshold").set_active_id(low_battery_threshold)
 
         udev_enabled = (config.get("udev-enabled","True").lower() == "true")
         self.builder.get_object("ui_udev_enabled").set_state(udev_enabled)
         self.builder.get_object("ui_udev_settings").set_sensitive(udev_enabled)
+        self.builder.get_object("ui_low_battery_mode").set_sensitive(low_battery_state)
+        self.builder.get_object("ui_low_battery_threshold").set_sensitive(low_battery_state)
 
         ##################################################################################
         ##################################################################################
@@ -223,13 +228,22 @@ class MainWindow:
         config.set("udev-enabled",str(state))
         self.builder.get_object("ui_udev_settings").set_sensitive(state)
 
+    def ui_low_battery_state_set(self, switch, state):
+        config.set("low-battery-enabled", str(state))
+        self.builder.get_object("ui_low_battery_mode").set_sensitive(state)
+        self.builder.get_object("ui_low_battery_threshold").set_sensitive(state)
+
+    def ui_low_profile_changed(self, combobox):
+        config.set("low-battery-profile",combobox.get_active_id())
+    
+    def ui_low_battery_threshold_changed(self, combobox):
+        config.set("low-battery-threshold",combobox.get_active_id())
+
     def ui_mode_battery_changed(self, combobox):
-        power_names = ["xpowersave", "powersave", "balanced", "performance", "xperformance"]
-        config.set("ppm-mode-battery",power_names.index(combobox.get_active_id()))
+        config.set("ppm-mode-battery",combobox.get_active_id())
 
     def ui_mode_ac_changed(self, combobox):
-        power_names = ["xpowersave", "powersave", "balanced", "performance", "xperformance"]
-        config.set("ppm-mode-ac",power_names.index(combobox.get_active_id()))
+        config.set("ppm-mode-ac",combobox.get_active_id())
 
 
     def ui_about_button_clicked(self,button):

--- a/src/main.py
+++ b/src/main.py
@@ -19,8 +19,6 @@ import dbus.mainloop.glib
 import dbus.service
 
 import time
-import threading
-import config
 
 class Service(dbus.service.Object):
     def __init__(self, message):
@@ -60,6 +58,7 @@ def stop_signals(signum, frame):
 
 if __name__ == "__main__":
     setproctitle.setproctitle("pardus-power-manager")
+    import config
     config = config.config()
     if tools.detect.is_virtual_machine():
         print("Virtual machine detected!")
@@ -101,7 +100,7 @@ if __name__ == "__main__":
             sys.exit(0)
     if not os.path.exists("/etc/xdg/autostart/ppm-autostart.desktop"):
         config.set("is-app-active","true")
-        # os.symlink("/usr/share/pardus/power-manager/ppm-autostart.desktop","/etc/xdg/autostart/ppm-autostart.desktop")
+        os.symlink("/usr/share/pardus/power-manager/ppm-autostart.desktop","/etc/xdg/autostart/ppm-autostart.desktop")
         if not os.path.exists("/lib/udev/rules.d/99-ppm.rules"):
             os.symlink("/usr/share/pardus/power-manager/udev.rules","/lib/udev/rules.d/99-ppm.rules")
     if config.get("low-battery-enabled", "true"):

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,10 @@ import dbus
 import dbus.mainloop.glib
 import dbus.service
 
+import time
+import threading
+import config
+
 class Service(dbus.service.Object):
     def __init__(self, message):
         self._message = message
@@ -56,7 +60,6 @@ def stop_signals(signum, frame):
 
 if __name__ == "__main__":
     setproctitle.setproctitle("pardus-power-manager")
-    import config
     config = config.config()
     if tools.detect.is_virtual_machine():
         print("Virtual machine detected!")
@@ -93,17 +96,16 @@ if __name__ == "__main__":
         elif config.get("force-enable-app","false").lower() != "true":
             sys.exit(0)
 
-
-
     if config.get("is-app-active","true").lower() != "true":
         if "--autostart" in sys.argv:
             sys.exit(0)
     if not os.path.exists("/etc/xdg/autostart/ppm-autostart.desktop"):
         config.set("is-app-active","true")
-        os.symlink("/usr/share/pardus/power-manager/ppm-autostart.desktop","/etc/xdg/autostart/ppm-autostart.desktop")
+        # os.symlink("/usr/share/pardus/power-manager/ppm-autostart.desktop","/etc/xdg/autostart/ppm-autostart.desktop")
         if not os.path.exists("/lib/udev/rules.d/99-ppm.rules"):
             os.symlink("/usr/share/pardus/power-manager/udev.rules","/lib/udev/rules.d/99-ppm.rules")
-
+    if config.get("low-battery-enabled", "true"):
+        tools.profile.start_battery_control()
     signal.signal(signal.SIGINT, stop_signals)
     signal.signal(signal.SIGTERM, stop_signals)
     # Dbus server and client for single instange window.

--- a/src/udev-trigger.py
+++ b/src/udev-trigger.py
@@ -16,7 +16,10 @@ if not tools.utils.checkIfProcessRunning("pardus-power-manager"):
 if config.get("udev-enabled","True").lower() != "true":
     exit(0)
 
-ac_online = tools.profile.get_ac_online()
+ac_online = False
+if "--on-ac" in sys.argv:
+	ac_online = True
+
 log = open("/var/log/ppm.log","a")
 
 if os.path.exists("/var/cache/ppm.last"):

--- a/ui/MainWindow.glade
+++ b/ui/MainWindow.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkAboutDialog" id="dialog_about">
@@ -647,11 +647,11 @@ Performance</property>
                                         <property name="can-focus">False</property>
                                         <property name="active">3</property>
                                         <items>
-                                          <item id="xpowersave" translatable="yes">Extreme Powersave</item>
-                                          <item id="powersave" translatable="yes">Powersave</item>
-                                          <item id="balanced" translatable="yes">Balanced</item>
-                                          <item id="performance" translatable="yes">Performance</item>
-                                          <item id="xperformance" translatable="yes">Extreme Performance</item>
+                                          <item id="0" translatable="yes">Extreme Powersave</item>
+                                          <item id="1" translatable="yes">Powersave</item>
+                                          <item id="2" translatable="yes">Balanced</item>
+                                          <item id="3" translatable="yes">Performance</item>
+                                          <item id="4" translatable="yes">Extreme Performance</item>
                                         </items>
                                         <signal name="changed" handler="ui_mode_ac_changed" swapped="no"/>
                                       </object>
@@ -691,11 +691,11 @@ Performance</property>
                                         <property name="can-focus">False</property>
                                         <property name="active">1</property>
                                         <items>
-                                          <item id="xpowersave" translatable="yes">Extreme Powersave</item>
-                                          <item id="powersave" translatable="yes">Powersave</item>
-                                          <item id="balanced" translatable="yes">Balanced</item>
-                                          <item id="performance" translatable="yes">Performance</item>
-                                          <item id="xperformance" translatable="yes">Extreme Performance</item>
+                                          <item id="0" translatable="yes">Extreme Powersave</item>
+                                          <item id="1" translatable="yes">Powersave</item>
+                                          <item id="2" translatable="yes">Balanced</item>
+                                          <item id="3" translatable="yes">Performance</item>
+                                          <item id="4" translatable="yes">Extreme Performance</item>
                                         </items>
                                         <signal name="changed" handler="ui_mode_battery_changed" swapped="no"/>
                                       </object>
@@ -717,6 +717,133 @@ Performance</property>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Change profile on low battery</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="ui_low_battery">
+                                    <property name="name">charge_mode</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="active">True</property>
+                                    <signal name="state-set" handler="ui_low_battery_state_set" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Power profile on low battery</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBoxText" id="ui_low_battery_mode">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="active">0</property>
+                                    <items>
+                                      <item id="0" translatable="yes">Extreme Powersave</item>
+                                      <item id="1" translatable="yes">Powersave</item>
+                                      <item id="2" translatable="yes">Balanced</item>
+                                      <item id="3" translatable="yes">Performance</item>
+                                      <item id="4" translatable="yes">Extreme Performance</item>
+                                    </items>
+                                    <signal name="changed" handler="ui_low_profile_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Low battery threshold</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBoxText" id="ui_low_battery_threshold">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="active">0</property>
+                                    <items>
+                                      <item id="5" translatable="yes">5</item>
+                                      <item id="10" translatable="yes">10</item>
+                                      <item id="15" translatable="yes">15</item>
+                                      <item id="20" translatable="yes">20</item>
+                                      <item id="25" translatable="yes">25</item>
+                                      <item id="30" translatable="yes">30</item>
+                                    </items>
+                                    <signal name="changed" handler="ui_low_battery_threshold_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
Bu pull-request teknofest pardus yarışması için yapılmıştır. Başvuru id'im: 1097384
1. commitle yaptığım: udev-trigger.py çalıştırılırken --on-bat veya --on-ac argümanı veriliyordu ancak udev-trigger.py'da bu argümanlar kontrol edilmiyor, tools.profile.get_ac_online fonksiyonuyla hesaplanıyordu. Bunun yerine argümana göre belirlemesi sağlandı.
2. commitle yaptıklarım: Pilin seviyesini (udev kuralıyla olmadığı için) her 5 saniyede bir kontrol eden fonksiyon ve bunu başlatan fonksiyon eklendi. Ayarlar kısmına bu özelliği açıp kapatma butonu, pil seviyesi düştüğünde hangi profile değiştirileceği ayarlanabilen bir dropdown buton ve pil seviyesi kaça düştüğünde profil değiştirileceği ayarlanabilen bir dropdown menü eklendi. Bu ayarlar diğerleri gibi /etc/pardus/ppm.conf'da depolanmaktadır. Bu committe yaptığım diğer değişiklik de ayarlardaki dropdown menülerin elemanlarının idlerinin değiştirilmesi: normalde idler "xpowersave" gibisinden bir string iken bu stringin kullanılması için bir dizi tanımlanması ve bu dizideki indeksi belirlenmesi gerekiyordu. Bunun yerine bu dropdownlara indeksleri koydum, böylece bu diziye veya hesaplamaya gerek kalmadı.